### PR TITLE
use sys/endian.h on FreeBSD

### DIFF
--- a/bitfn.h
+++ b/bitfn.h
@@ -67,6 +67,8 @@ static inline uint64_t swap64(uint64_t a)
 /* big endian to cpu */
 #ifdef __APPLE__
 #include <architecture/byte_order.h>
+#elif __FreeBSD__
+#include <sys/endian.h>
 #else
 #include <endian.h>
 #endif


### PR DESCRIPTION
ocaml-sha doesn't compile on FreeBSD, this fixes it... we might be able to use `sys/endian.h` on all UNIX systems?
