### PR TITLE
sha1.ml should have types compatible to sha1.mli

### DIFF
--- a/sha1.ml
+++ b/sha1.ml
@@ -14,7 +14,7 @@
  *)
 
 type ctx
-type buf = (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+type buf = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 type t
 
 external init: unit -> ctx = "stub_sha1_init"


### PR DESCRIPTION
Fixes issue introduced in #13.
