### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ env:
    - PINS="sha:."
    - PACKAGE="sha"
  matrix:
-   - DISTRO=alpine OCAML_VERSION=4.02.0
+   - DISTRO=alpine OCAML_VERSION=4.02.3
    - DISTRO=alpine OCAML_VERSION=4.06.0


### PR DESCRIPTION
The alpine 4.02.0 base image no longer exists, but 4.02.3 does.

Fixes #30.
