### PR TITLE
Don't access caml values without acquired runtime

### DIFF
--- a/sha1_stubs.c
+++ b/sha1_stubs.c
@@ -24,6 +24,7 @@ typedef SSIZE_T ssize_t;
 #else
 #include <unistd.h>
 #endif
+#include <string.h>
 #include <fcntl.h>
 #include <string.h>
 #include "sha1.h"
@@ -87,12 +88,15 @@ CAMLprim value stub_sha1_update(value ctx, value data, value ofs, value len)
 CAMLprim value stub_sha1_update_bigarray(value ctx, value buf)
 {
 	CAMLparam2(ctx, buf);
+	struct sha1_ctx ctx_dup;
 	unsigned char *data = Data_bigarray_val(buf);
 	size_t len = Bigarray_val(buf)->dim[0];
 
+	ctx_dup = *GET_CTX_STRUCT(ctx);
 	caml_release_runtime_system();
-	sha1_update(GET_CTX_STRUCT(ctx), data, len);
+	sha1_update(&ctx_dup, data, len);
 	caml_acquire_runtime_system();
+	*GET_CTX_STRUCT(ctx) = ctx_dup;
 
 	CAMLreturn(Val_unit);
 }

--- a/sha256_stubs.c
+++ b/sha256_stubs.c
@@ -24,6 +24,7 @@ typedef SSIZE_T ssize_t;
 #else
 #include <unistd.h>
 #endif
+#include <string.h>
 #include <fcntl.h>
 #include <string.h>
 #include "sha256.h"
@@ -86,12 +87,15 @@ CAMLprim value stub_sha256_update(value ctx, value data, value ofs, value len)
 CAMLprim value stub_sha256_update_bigarray(value ctx, value buf)
 {
 	CAMLparam2(ctx, buf);
+	struct sha256_ctx ctx_dup;
 	unsigned char *data = Data_bigarray_val(buf);
 	size_t len = Bigarray_val(buf)->dim[0];
 
+	ctx_dup = *GET_CTX_STRUCT(ctx);
 	caml_release_runtime_system();
-	sha256_update(GET_CTX_STRUCT(ctx), data, len);
+	sha256_update(&ctx_dup, data, len);
 	caml_acquire_runtime_system();
+	*GET_CTX_STRUCT(ctx) = ctx_dup;
 
 	CAMLreturn(Val_unit);
 }

--- a/sha512_stubs.c
+++ b/sha512_stubs.c
@@ -24,6 +24,7 @@ typedef SSIZE_T ssize_t;
 #else
 #include <unistd.h>
 #endif
+#include <string.h>
 #include <fcntl.h>
 #include <string.h>
 #include "sha512.h"
@@ -86,12 +87,15 @@ CAMLprim value stub_sha512_update(value ctx, value data, value ofs, value len)
 CAMLprim value stub_sha512_update_bigarray(value ctx, value buf)
 {
 	CAMLparam2(ctx, buf);
+	struct sha512_ctx ctx_dup;
 	unsigned char *data = Data_bigarray_val(buf);
 	size_t len = Bigarray_val(buf)->dim[0];
 
+	ctx_dup = *GET_CTX_STRUCT(ctx);
 	caml_release_runtime_system();
-	sha512_update(GET_CTX_STRUCT(ctx), data, len);
+	sha512_update(&ctx_dup, data, len);
 	caml_acquire_runtime_system();
+	*GET_CTX_STRUCT(ctx) = ctx_dup;
 
 	CAMLreturn(Val_unit);
 }


### PR DESCRIPTION
We mustn't access the context in a custom block while the runtime is released.
It might be relocated from minor to major heap or during major heap compaction.

Also include string.h for memcpy().

Cherry-picked from #23.