### PR TITLE
Fix MSVC compilation

### DIFF
--- a/sha1_stubs.c
+++ b/sha1_stubs.c
@@ -17,7 +17,13 @@
  */
 
 #define _GNU_SOURCE
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#define alloca _alloca
+#else
 #include <unistd.h>
+#endif
 #include <fcntl.h>
 #include "sha1.h"
 

--- a/sha256_stubs.c
+++ b/sha256_stubs.c
@@ -17,7 +17,13 @@
  */
 
 #define _GNU_SOURCE
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#define alloca _alloca
+#else
 #include <unistd.h>
+#endif
 #include <fcntl.h>
 #include "sha256.h"
 

--- a/sha512_stubs.c
+++ b/sha512_stubs.c
@@ -17,7 +17,13 @@
  */
 
 #define _GNU_SOURCE
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#define alloca _alloca
+#else
 #include <unistd.h>
+#endif
 #include <fcntl.h>
 #include "sha512.h"
 


### PR DESCRIPTION
This patch should fix compilation under MSVC. The (current, `Makefile`-based) build system does not work under MSVC, but it should work if we switch to `jbuilder` or if built by hand.