### PR TITLE
logic “any and every non-windoze has O_CLOEXEC” is false

### DIFF
--- a/sha1_stubs.c
+++ b/sha1_stubs.c
@@ -36,7 +36,7 @@ static inline int sha1_file(char *filename, sha1_digest *digest)
 	int fd; ssize_t n;
 	struct sha1_ctx ctx;
 
-#ifdef WIN32
+#ifndef O_CLOEXEC
 	fd = open(filename, O_RDONLY);
 #else
 	fd = open(filename, O_RDONLY | O_CLOEXEC);

--- a/sha256_stubs.c
+++ b/sha256_stubs.c
@@ -36,7 +36,7 @@ static inline int sha256_file(char *filename, sha256_digest *digest)
 	int fd; ssize_t n;
 	struct sha256_ctx ctx;
 
-#ifdef WIN32
+#ifndef O_CLOEXEC
 	fd = open(filename, O_RDONLY);
 #else
 	fd = open(filename, O_RDONLY | O_CLOEXEC);

--- a/sha512_stubs.c
+++ b/sha512_stubs.c
@@ -36,7 +36,7 @@ static inline int sha512_file(char *filename, sha512_digest *digest)
 	int fd; ssize_t n;
 	struct sha512_ctx ctx;
 
-#ifdef WIN32
+#ifndef O_CLOEXEC
 	fd = open(filename, O_RDONLY);
 #else
 	fd = open(filename, O_RDONLY | O_CLOEXEC);


### PR DESCRIPTION
there are other platforms, like Linux < 2.6.23, which don’t have it