### PR TITLE
support other platforms without O_CLOEXEC as well as Windows

### DIFF
--- a/sha1_stubs.c
+++ b/sha1_stubs.c
@@ -36,7 +36,7 @@ static inline int sha1_file(char *filename, sha1_digest *digest)
 	int fd; ssize_t n;
 	struct sha1_ctx ctx;
 
-#ifdef _WIN32
+#ifndef O_CLOEXEC
 	fd = open(filename, O_RDONLY);
 #else
 	fd = open(filename, O_RDONLY | O_CLOEXEC);

--- a/sha256_stubs.c
+++ b/sha256_stubs.c
@@ -36,7 +36,7 @@ static inline int sha256_file(char *filename, sha256_digest *digest)
 	int fd; ssize_t n;
 	struct sha256_ctx ctx;
 
-#ifdef _WIN32
+#ifndef O_CLOEXEC
 	fd = open(filename, O_RDONLY);
 #else
 	fd = open(filename, O_RDONLY | O_CLOEXEC);

--- a/sha512_stubs.c
+++ b/sha512_stubs.c
@@ -36,7 +36,7 @@ static inline int sha512_file(char *filename, sha512_digest *digest)
 	int fd; ssize_t n;
 	struct sha512_ctx ctx;
 
-#ifdef _WIN32
+#ifndef O_CLOEXEC
 	fd = open(filename, O_RDONLY);
 #else
 	fd = open(filename, O_RDONLY | O_CLOEXEC);


### PR DESCRIPTION
This is a rebase of #41 by @dougmencken

Fixes #41 

Signed-off-by: David Scott <dave@recoil.org>