### PR TITLE
Remove --dev option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	dune build --dev @install
+	dune build @install
 
 test:
 	dune runtest


### PR DESCRIPTION
It seems dune 2 doesn't support this option anymore.

From man:
```
 --profile=VAL (absent DUNE_PROFILE env)
     Select the build profile, for instance dev or release. The default is dev.
```
