### PR TITLE
Add `of_hex` and `of_bin` functions

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -19,6 +19,7 @@
          "Nicolás Ojeda Bär"
          "Christopher Zimmermann"
          "Thomas Leonard"
+         "Antonin Décimo"
 )
 
 (maintainers dave@recoil.org)
@@ -29,6 +30,6 @@
  (description "This is the binding for SHA interface code in OCaml. Offering the same
 interface than the MD5 digest included in the OCaml standard library.
 It's currently providing SHA1, SHA256 and SHA512 hash functions.")
- (depends (dune (>= 2.0)) (stdlib-shims (>= 0.3.0)) (ounit :with-test)))
+ (depends (dune (>= 2.0)) (stdlib-shims (>= 0.3.0)) (ounit2 :with-test)))
 
 (generate_opam_files true)

--- a/sha.opam
+++ b/sha.opam
@@ -20,6 +20,7 @@ authors: [
   "Nicolás Ojeda Bär"
   "Christopher Zimmermann"
   "Thomas Leonard"
+  "Antonin Décimo"
 ]
 license: "ISC"
 homepage: "https://github.com/djs55/ocaml-sha"
@@ -27,7 +28,7 @@ bug-reports: "https://github.com/djs55/ocaml-sha/issues"
 depends: [
   "dune" {>= "2.0"}
   "stdlib-shims" {>= "0.3.0"}
-  "ounit" {with-test}
+  "ounit2" {with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/sha1.h
+++ b/sha1.h
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "bitfn.h"
+#include "util.h"
 
 struct sha1_ctx
 {
@@ -286,6 +287,24 @@ static void sha1_to_hex(sha1_digest *digest, char *out)
 	snprintf(out, 41, "%08x%08x%08x%08x%08x",
 		D(0), D(1), D(2), D(3), D(4));
 	#undef D
+}
+
+/**
+ * sha1_of_bin - Transform binary data into the SHA1 digest
+ */
+static void sha1_of_bin(const char *in, sha1_digest *digest)
+{
+	memcpy(digest->digest, in, sizeof(*digest));
+}
+
+/**
+ * sha1_of_hex - Transform readable data into the SHA1 digest
+ */
+static void sha1_of_hex(const char *in, sha1_digest *digest)
+{
+	if (strlen(in) != 40)
+		return;
+	of_hex((unsigned char *) digest->digest, in, 40);
 }
 
 #endif

--- a/sha1.ml
+++ b/sha1.ml
@@ -27,6 +27,8 @@ external finalize: ctx -> t = "stub_sha1_finalize"
 external copy : ctx -> ctx = "stub_sha1_copy"
 external to_bin: t -> string = "stub_sha1_to_bin"
 external to_hex: t -> string = "stub_sha1_to_hex"
+external of_bin: bytes -> t = "stub_sha1_of_bin"
+external of_hex: string -> t = "stub_sha1_of_hex"
 external file_fast: string -> t = "stub_sha1_file"
 external equal: t -> t -> bool = "stub_sha1_equal"
 

--- a/sha1.mli
+++ b/sha1.mli
@@ -93,3 +93,11 @@ val to_hex : t -> string
 
 (** Returns whether two hashes are equal. *)
 val equal : t -> t -> bool
+
+(** Sha1.of_bin digest converts the binary representation of a digest to the
+   internal representation of Sha1.t. *)
+val of_bin : bytes -> t
+
+(** Sha1.of_hex digest converts the hexadecimal representation of a digest to
+   the internal representation of Sha1.t. *)
+val of_hex : string -> t

--- a/sha1_stubs.c
+++ b/sha1_stubs.c
@@ -176,3 +176,25 @@ CAMLprim value stub_sha1_equal(value t1, value t2)
 	int b = memcmp((sha1_digest *) t1, (sha1_digest *) t2, sizeof(sha1_digest)) == 0;
 	CAMLreturn(Bool_val(b));
 }
+
+CAMLprim value stub_sha1_of_bin(value bin)
+{
+	CAMLparam1(bin);
+	CAMLlocal1(result);
+
+	result = caml_alloc(sizeof(sha1_digest), Abstract_tag);
+	sha1_of_bin((const char *) Bytes_val(bin), (sha1_digest *) result);
+
+	CAMLreturn(result);
+}
+
+CAMLprim value stub_sha1_of_hex(value hex)
+{
+	CAMLparam1(hex);
+	CAMLlocal1(result);
+
+	result = caml_alloc(sizeof(sha1_digest), Abstract_tag);
+	sha1_of_hex(String_val(hex), (sha1_digest *) result);
+
+	CAMLreturn(result);
+}

--- a/sha256.h
+++ b/sha256.h
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "bitfn.h"
+#include "util.h"
 
 struct sha256_ctx
 {
@@ -231,6 +232,24 @@ static void sha256_to_hex(sha256_digest *digest, char *out)
 
 	for (p = out, i = 0; i < 8; i++, p += 8)
 		snprintf(p, 9, "%08x", be32_to_cpu(digest->digest[i]));
+}
+
+/**
+ * sha256_of_bin - Transform binary data into the SHA256 digest
+ */
+static void sha256_of_bin(const char *in, sha256_digest *digest)
+{
+	memcpy(digest->digest, in, sizeof(*digest));
+}
+
+/**
+ * sha256_of_hex - Transform readable data into the SHA256 digest
+ */
+static void sha256_of_hex(const char *in, sha256_digest *digest)
+{
+	if (strlen(in) != 64)
+		return;
+	of_hex((unsigned char *) digest->digest, in, 64);
 }
 
 #endif

--- a/sha256.ml
+++ b/sha256.ml
@@ -27,6 +27,8 @@ external finalize: ctx -> t = "stub_sha256_finalize"
 external copy : ctx -> ctx = "stub_sha256_copy"
 external to_bin: t -> string = "stub_sha256_to_bin"
 external to_hex: t -> string = "stub_sha256_to_hex"
+external of_bin: bytes -> t = "stub_sha256_of_bin"
+external of_hex: string -> t = "stub_sha256_of_hex"
 external file_fast: string -> t = "stub_sha256_file"
 external equal: t -> t -> bool = "stub_sha256_equal"
 

--- a/sha256.mli
+++ b/sha256.mli
@@ -92,3 +92,11 @@ val to_hex : t -> string
 
 (** Returns whether two hashes are equal. *)
 val equal : t -> t -> bool
+
+(** Sha256.of_bin digest converts the binary representation of a digest to the
+   internal representation of Sha256.t. *)
+val of_bin : bytes -> t
+
+(** Sha256.of_hex digest converts the hexadecimal representation of a digest to
+   the internal representation of Sha256.t. *)
+val of_hex : string -> t

--- a/sha256_stubs.c
+++ b/sha256_stubs.c
@@ -174,3 +174,25 @@ CAMLprim value stub_sha256_equal(value t1, value t2)
 	int b = memcmp((sha256_digest *) t1, (sha256_digest *) t2, sizeof(sha256_digest)) == 0;
 	CAMLreturn(Bool_val(b));
 }
+
+CAMLprim value stub_sha256_of_bin(value bin)
+{
+	CAMLparam1(bin);
+	CAMLlocal1(result);
+
+	result = caml_alloc(sizeof(sha256_digest), Abstract_tag);
+	sha256_of_bin((const char *) Bytes_val(bin), (sha256_digest *) result);
+
+	CAMLreturn(result);
+}
+
+CAMLprim value stub_sha256_of_hex(value hex)
+{
+	CAMLparam1(hex);
+	CAMLlocal1(result);
+
+	result = caml_alloc(sizeof(sha256_digest), Abstract_tag);
+	sha256_of_hex(String_val(hex), (sha256_digest *) result);
+
+	CAMLreturn(result);
+}

--- a/sha512.h
+++ b/sha512.h
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "bitfn.h"
+#include "util.h"
 
 struct sha512_ctx
 {
@@ -254,7 +255,25 @@ static void sha512_to_hex(sha512_digest *digest, char *out)
 
 	for (p = out, i = 0; i < 8; i++, p += 16)
 		snprintf(p, 17, "%016llx",
-		         (unsigned long long) be64_to_cpu(digest->digest[i]));
+                         (unsigned long long) be64_to_cpu(digest->digest[i]));
+}
+
+/**
+ * sha512_of_bin - Transform binary data into the SHA512 digest
+ */
+static void sha512_of_bin(const char *in, sha512_digest *digest)
+{
+	memcpy(digest->digest, in, sizeof(*digest));
+}
+
+/**
+ * sha512_of_hex - Transform readable data into the SHA512 digest
+ */
+static void sha512_of_hex(const char *in, sha512_digest *digest)
+{
+	if (strlen(in) != 128)
+		return;
+	of_hex((unsigned char *) digest->digest, in, 128);
 }
 
 #endif

--- a/sha512.ml
+++ b/sha512.ml
@@ -27,6 +27,8 @@ external finalize: ctx -> t = "stub_sha512_finalize"
 external copy : ctx -> ctx = "stub_sha512_copy"
 external to_bin: t -> string = "stub_sha512_to_bin"
 external to_hex: t -> string = "stub_sha512_to_hex"
+external of_bin: bytes -> t = "stub_sha256_of_bin"
+external of_hex: string -> t = "stub_sha256_of_hex"
 external file_fast: string -> t = "stub_sha512_file"
 external equal: t -> t -> bool = "stub_sha512_equal"
 

--- a/sha512.mli
+++ b/sha512.mli
@@ -92,3 +92,11 @@ val to_hex : t -> string
 
 (** Returns whether two hashes are equal. *)
 val equal : t -> t -> bool
+
+(** Sha512.of_bin digest converts the binary representation of a digest to the
+   internal representation of Sha512.t. *)
+val of_bin : bytes -> t
+
+(** Sha512.of_hex digest converts the hexadecimal representation of a digest to
+   the internal representation of Sha512.t. *)
+val of_hex : string -> t

--- a/sha512_stubs.c
+++ b/sha512_stubs.c
@@ -174,3 +174,25 @@ CAMLprim value stub_sha512_equal(value t1, value t2)
 	int b = memcmp((sha512_digest *) t1, (sha512_digest *) t2, sizeof(sha512_digest)) == 0;
 	CAMLreturn(Bool_val(b));
 }
+
+CAMLprim value stub_sha512_of_bin(value bin)
+{
+	CAMLparam1(bin);
+	CAMLlocal1(result);
+
+	result = caml_alloc(sizeof(sha512_digest), Abstract_tag);
+	sha512_of_bin((const char *) Bytes_val(bin), (sha512_digest *) result);
+
+	CAMLreturn(result);
+}
+
+CAMLprim value stub_sha512_of_hex(value hex)
+{
+	CAMLparam1(hex);
+	CAMLlocal1(result);
+
+	result = caml_alloc(sizeof(sha512_digest), Abstract_tag);
+	sha512_of_hex(String_val(hex), (sha512_digest *) result);
+
+	CAMLreturn(result);
+}

--- a/test/dune
+++ b/test/dune
@@ -6,7 +6,7 @@
 (executable
  (name shatest)
  (modules shatest)
- (libraries sha oUnit))
+ (libraries sha ounit2))
 
 (rule
  (alias runtest)

--- a/test/shatest.ml
+++ b/test/shatest.ml
@@ -69,9 +69,13 @@ let ex_channels_sha512 =
 	[ ("sample.txt",
 	"07e547d9586f6a73f73fbac0435ed76951218fb7d0c8d788a309d785436bbb642e93a252a954f23912547d1e8a3b5ed6e1bfd7097821233fa0538f3db854fee6") ]
 
-let stringfct_sha1 s = Sha1.to_hex (Sha1.string s)
-let stringfct_sha256 s = Sha256.to_hex (Sha256.string s)
-let stringfct_sha512 s = Sha512.to_hex (Sha512.string s)
+let stringfct_hex_sha1 s = Sha1.to_hex (Sha1.string s)
+let stringfct_hex_sha256 s = Sha256.to_hex (Sha256.string s)
+let stringfct_hex_sha512 s = Sha512.to_hex (Sha512.string s)
+
+let stringfct_bin_sha1 s = Sha1.to_bin (Sha1.string s)
+let stringfct_bin_sha256 s = Sha256.to_bin (Sha256.string s)
+let stringfct_bin_sha512 s = Sha512.to_bin (Sha512.string s)
 
 let filefct_sha1 s = Sha1.to_hex (Sha1.file s)
 let filefct_sha256 s = Sha256.to_hex (Sha256.file s)
@@ -103,31 +107,46 @@ let test_equal string eq arr _ =
 	s)
 	(List.hd arr |> fst) arr |> ignore
 
+let test_of stringfct_to stringfct_of arr _ =
+	List.iter (fun (s,_) -> assert_equal (stringfct_to s) (stringfct_of s)) arr
+
 let suite = "SHA binding test" >:::
 	[ "SHA1 example strings" >::
-		test_strings stringfct_sha1 ex_strings_sha1;
+		test_strings stringfct_hex_sha1 ex_strings_sha1;
 	  "SHA1 reading a file" >::
 		test_file filefct_sha1 ex_files_sha1;
 	  "SHA1 reading few byte from channel" >::
 		test_channel channelfct_sha1 ex_channels_sha1;
 	  "SHA1 equality" >::
 		test_equal Sha1.string Sha1.equal ex_strings_sha1;
+	  "SHA1 converting from binary representation" >::
+		test_of stringfct_bin_sha1 (fun s -> Sha1.(string s |> to_bin |> Bytes.of_string |> of_bin |> to_bin)) ex_strings_sha1;
+	  "SHA1 converting from hexadecimal representation" >::
+		test_of stringfct_hex_sha1 (fun s -> Sha1.(string s |> to_hex |> of_hex |> to_hex)) ex_strings_sha1;
 	  "SHA256 example strings" >::
-		test_strings stringfct_sha256 ex_strings_sha256;
+		test_strings stringfct_hex_sha256 ex_strings_sha256;
 	  "SHA256 reading a file" >::
 		test_file filefct_sha256 ex_files_sha256;
 	  "SHA256 reading few byte from channel" >::
 		test_channel channelfct_sha256 ex_channels_sha256;
 	  "SHA256 equality" >::
 		test_equal Sha256.string Sha256.equal ex_strings_sha256;
+	  "SHA256 converting from binary representation" >::
+		test_of stringfct_bin_sha256 (fun s -> Sha256.(string s |> to_bin |> Bytes.of_string |> of_bin |> to_bin)) ex_strings_sha256;
+	  "SHA256 converting from hexadecimal representation" >::
+		test_of stringfct_hex_sha256 (fun s -> Sha256.(string s |> to_hex |> of_hex |> to_hex)) ex_strings_sha256;
 	  "SHA512 example strings" >::
-		test_strings stringfct_sha512 ex_strings_sha512;
+		test_strings stringfct_hex_sha512 ex_strings_sha512;
 	  "SHA512 reading a file" >::
 		test_file filefct_sha512 ex_files_sha512;
 	  "SHA512 reading few byte from channel" >::
 		test_channel channelfct_sha512 ex_channels_sha512;
 	  "SHA512 equality" >::
 		test_equal Sha512.string Sha512.equal ex_strings_sha512;
+	  "SHA1 converting from binary representation" >::
+		test_of stringfct_bin_sha1 (fun s -> Sha1.(string s |> to_bin |> Bytes.of_string |> of_bin |> to_bin)) ex_strings_sha1;
+	  "SHA1 converting from hexadecimal representation" >::
+		test_of stringfct_hex_sha1 (fun s -> Sha1.(string s |> to_hex |> of_hex |> to_hex)) ex_strings_sha1;
 	]
 
 let _ = run_test_tt ~verbose:true suite

--- a/util.h
+++ b/util.h
@@ -1,0 +1,35 @@
+#ifndef UTIL_H
+#define UTIL_H
+
+static int hex_to_int(char c)
+{
+    if ('0' <= c && c <= '9')
+        return c - '0';
+    else if ('a' <= c && c <= 'f')
+        return c - 'a' + 10;
+    else if ('A' <= c && c <= 'F')
+        return c - 'A' + 10;
+    else
+        return -1;
+}
+
+static int of_hex(unsigned char *dst, const char *src, int n)
+{
+    int i;
+
+    if (n % 2 != 0)
+        return -1;
+    for (i = 0; i < n/2; i++) {
+        int a, b;
+        a = hex_to_int(src[i*2]);
+        if(a < 0)
+            return -1;
+        b = hex_to_int(src[i*2 + 1]);
+        if(b < 0)
+            return -1;
+        dst[i] = a*16 + b;
+    }
+    return n/2;
+}
+
+#endif


### PR DESCRIPTION
It's easy to serialize a `ShaX.t` value: just convert it to its
hexadecimal or binary representation. However, the library doesn't
provide any means of unserializing the value.

This commit introduces functions to unserialize `ShaX.t` values from a
binary or an hexadecimal representation of a digest.

I'd like to share the `hex_to_int` and `of_hex` functions between the
modules, would you be fine with adding an `util.h` file to the
library?