### PR TITLE
Use modern bigarray functions (5.00 compatibility)

### DIFF
--- a/sha1_stubs.c
+++ b/sha1_stubs.c
@@ -94,8 +94,8 @@ CAMLprim value stub_sha1_update_bigarray(value ctx, value buf)
 {
 	CAMLparam2(ctx, buf);
 	struct sha1_ctx ctx_dup;
-	unsigned char *data = Data_bigarray_val(buf);
-	size_t len = Bigarray_val(buf)->dim[0];
+	unsigned char *data = Caml_ba_data_val(buf);
+	size_t len = Caml_ba_array_val(buf)->dim[0];
 
 	ctx_dup = *GET_CTX_STRUCT(ctx);
 	caml_release_runtime_system();

--- a/sha256_stubs.c
+++ b/sha256_stubs.c
@@ -93,8 +93,8 @@ CAMLprim value stub_sha256_update_bigarray(value ctx, value buf)
 {
 	CAMLparam2(ctx, buf);
 	struct sha256_ctx ctx_dup;
-	unsigned char *data = Data_bigarray_val(buf);
-	size_t len = Bigarray_val(buf)->dim[0];
+	unsigned char *data = Caml_ba_data_val(buf);
+	size_t len = Caml_ba_array_val(buf)->dim[0];
 
 	ctx_dup = *GET_CTX_STRUCT(ctx);
 	caml_release_runtime_system();

--- a/sha512_stubs.c
+++ b/sha512_stubs.c
@@ -93,8 +93,8 @@ CAMLprim value stub_sha512_update_bigarray(value ctx, value buf)
 {
 	CAMLparam2(ctx, buf);
 	struct sha512_ctx ctx_dup;
-	unsigned char *data = Data_bigarray_val(buf);
-	size_t len = Bigarray_val(buf)->dim[0];
+	unsigned char *data = Caml_ba_data_val(buf);
+	size_t len = Caml_ba_array_val(buf)->dim[0];
 
 	ctx_dup = *GET_CTX_STRUCT(ctx);
 	caml_release_runtime_system();


### PR DESCRIPTION
Introduced in 3.10. Old aliases removed in 5.00.