### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/bitfn.h
+++ b/bitfn.h
@@ -20,6 +20,10 @@
 #define BITFN_H
 #include <stdint.h>
 
+// NOTE: Required to build on OpenBSD
+#undef swap32
+#undef swap64
+
 static inline unsigned int rol32(unsigned int word, unsigned int shift)
 {
         return (word << shift) | (word >> (32 - shift));


### PR DESCRIPTION
On OpenBSD `swap32` and `swap64` are defines such that:
```
#define swap32(x) __swap32(x)
#define swap64(x) __swap64(x)
```
When defining those functions below the compilation failed with:
```
#=== ERROR while compiling sha.1.15.2 =========================================#
# context     2.2.0~alpha~dev | openbsd/x86_64 | ocaml-base-compiler.4.14.0 | https://opam.ocaml.org#245530a0
# path        ~/.opam/default/.opam-switch/build/sha.1.15.2
# command     ~/.opam/default/bin/dune build -p sha -j 1 --promote-install-files=false @install
# exit-code   1
# env-file    ~/.opam/log/sha-20406-d9480e.env
# output-file ~/.opam/log/sha-20406-d9480e.out
### output ###
# [...]
# /usr/include/machine/_types.h:68:28: note: previous definition is here
# typedef unsigned long long      __uint64_t;
#                                 ^
# In file included from sha512_stubs.c:30:
# In file included from ./sha512.h:25:
# ./bitfn.h:59:26: error: use of undeclared identifier 'a'
#         asm ("bswap %0" : "=r" (a) : "0" (a));
#                                 ^
# ./bitfn.h:60:9: error: use of undeclared identifier 'a'
#         return a;
#                ^
# 2 warnings and 8 errors generated.
```