### PR TITLE
Fix equality

### DIFF
--- a/sha1_stubs.c
+++ b/sha1_stubs.c
@@ -179,7 +179,7 @@ CAMLprim value stub_sha1_equal(value t1, value t2)
 {
 	CAMLparam2(t1, t2);
 	int b = memcmp((sha1_digest *) t1, (sha1_digest *) t2, sizeof(sha1_digest)) == 0;
-	CAMLreturn(Bool_val(b));
+	CAMLreturn(Val_bool(b));
 }
 
 CAMLprim value stub_sha1_of_bin(value bin)

--- a/sha256_stubs.c
+++ b/sha256_stubs.c
@@ -177,7 +177,7 @@ CAMLprim value stub_sha256_equal(value t1, value t2)
 {
 	CAMLparam2(t1, t2);
 	int b = memcmp((sha256_digest *) t1, (sha256_digest *) t2, sizeof(sha256_digest)) == 0;
-	CAMLreturn(Bool_val(b));
+	CAMLreturn(Val_bool(b));
 }
 
 CAMLprim value stub_sha256_of_bin(value bin)

--- a/sha512_stubs.c
+++ b/sha512_stubs.c
@@ -177,7 +177,7 @@ CAMLprim value stub_sha512_equal(value t1, value t2)
 {
 	CAMLparam2(t1, t2);
 	int b = memcmp((sha512_digest *) t1, (sha512_digest *) t2, sizeof(sha512_digest)) == 0;
-	CAMLreturn(Bool_val(b));
+	CAMLreturn(Val_bool(b));
 }
 
 CAMLprim value stub_sha512_of_bin(value bin)

--- a/test/shatest.ml
+++ b/test/shatest.ml
@@ -160,7 +160,7 @@ module Vectors = struct
     List.map
       (fun ((hash_name, hash), expect) ->
         let test_name = name ^ "_" ^ hash_name in
-        test_name >:: fun _ctx : unit ->
+        test_name >:: fun _ctx ->
           let res = hash input in
           assert_equal ~printer:(Printf.sprintf "%S") expect res)
       pairs


### PR DESCRIPTION
When returning an OCaml value we need to construct a value with a Val_ macro. Bool_val is for extracting an OCaml bool value to C.

Also make a trivial build fix for OCaml 4.02 for max compat.

Signed-off-by: David Scott <dave@recoil.org>